### PR TITLE
[FEAT] 모달 구현, 공부 페이지 작성

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "next": "14.2.12",
     "pnpm": "^9.12.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-icons": "^5.3.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "pnpm": "^9.12.0",
     "react": "^18",
     "react-dom": "^18",
-    "react-icons": "^5.3.0"
+    "react-icons": "^5.3.0",
+    "zustand": "5.0.0-rc.2"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
       next:
         specifier: 14.2.12
         version: 14.2.12(@babel/core@7.25.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      pnpm:
+        specifier: ^9.12.0
+        version: 9.12.1
       react:
         specifier: ^18
         version: 18.3.1
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      react-icons:
+        specifier: ^5.3.0
+        version: 5.3.0(react@18.3.1)
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -2089,6 +2095,11 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  pnpm@9.12.1:
+    resolution: {integrity: sha512-5aflKkGDoC1ZMQV/eg2/+dXpzjFh4z+miuOSElt5KCqKikcKUd/IoO2GIhRC6y+1cBmwmQ7ST6tRm/DhvFzPxA==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
@@ -2131,6 +2142,11 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-icons@5.3.0:
+    resolution: {integrity: sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4777,6 +4793,8 @@ snapshots:
 
   pluralize@8.0.0: {}
 
+  pnpm@9.12.1: {}
+
   possible-typed-array-names@1.0.0: {}
 
   postcss@8.4.31:
@@ -4818,6 +4836,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-icons@5.3.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@16.13.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-icons:
         specifier: ^5.3.0
         version: 5.3.0(react@18.3.1)
+      zustand:
+        specifier: 5.0.0-rc.2
+        version: 5.0.0-rc.2(@types/react@18.3.7)(react@18.3.1)
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -2625,6 +2628,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.0-rc.2:
+    resolution: {integrity: sha512-o2Nwuvnk8vQBX7CcHL8WfFkZNJdxB/VKeWw0tNglw8p4cypsZ3tRT7rTRTDNeUPFS0qaMBRSKe+fVwL5xpcE3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -5398,3 +5419,8 @@ snapshots:
   yaml@2.5.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.0-rc.2(@types/react@18.3.7)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.7
+      react: 18.3.1

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import "../styles/globals.css";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 
+import ModalProvider from "@/components/modal/modal-provider";
+
 import Header from "../components/header";
 
 const geistSans = localFont({
@@ -25,8 +27,11 @@ const Layout = (props: { children: React.ReactNode }) => {
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <Header />
-        <main>{props.children}</main>
+        <main>
+          <Header />
+          <ModalProvider>{props.children}</ModalProvider>
+          <div id="modal-root" />
+        </main>
       </body>
     </html>
   );

--- a/src/app/study/(components)/plan-box/plan-box.tsx
+++ b/src/app/study/(components)/plan-box/plan-box.tsx
@@ -1,0 +1,42 @@
+import { FaPlus } from "react-icons/fa6";
+
+import { PlanData } from "@/types/plan";
+
+import * as styles from "./styles.css";
+
+export default function PlanBox({
+  planData,
+  enterMode,
+}: {
+  planData: PlanData;
+  enterMode?: boolean;
+}) {
+  return (
+    <div>
+      {enterMode || <p className={styles.date}>{planData.date}</p>}
+      <div className={styles.container}>
+        <ul className={styles.planList}>
+          {planData.list.map(({ id, content, checked }) => (
+            <li key={id}>
+              <label>
+                <input type="checkbox" checked={checked} /> {content}
+              </label>
+            </li>
+          ))}
+        </ul>
+        {enterMode && (
+          <div className={styles.planInputSection}>
+            <input
+              type="text"
+              placeholder="오늘의 계획을 작성해주세요"
+              className={styles.planInput}
+            />
+            <button className={styles.planButton}>
+              <FaPlus />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/study/(components)/plan-box/plans.ts
+++ b/src/app/study/(components)/plan-box/plans.ts
@@ -1,0 +1,16 @@
+export const plans = {
+  date: "2024.10.08",
+  list: [
+    {
+      id: 0,
+      checked: true,
+      content: "[컴퓨터 네트워크] 네트워크 유형 학습하기",
+    },
+    { id: 1, checked: false, content: "[자료구조] DFS 퀴즈 풀기" },
+    {
+      id: 2,
+      checked: true,
+      content: "[운영체제] 공유자원과 임계구역 학습하기",
+    },
+  ],
+};

--- a/src/app/study/(components)/plan-box/styles.css.ts
+++ b/src/app/study/(components)/plan-box/styles.css.ts
@@ -1,0 +1,49 @@
+import { style } from "@vanilla-extract/css";
+
+export const date = style({
+  marginTop: 20,
+  marginBottom: -5,
+  fontWeight: "bold",
+});
+
+export const container = style({
+  marginTop: 15,
+  display: "flex",
+  padding: "25px",
+  border: "1px solid #93D092",
+  borderRadius: 12,
+  flexDirection: "column",
+});
+
+export const planList = style({
+  display: "flex",
+  flexDirection: "column",
+  gap: 10,
+});
+
+export const planInputSection = style({
+  display: "flex",
+  gap: 6,
+  marginTop: 20,
+});
+
+export const planInput = style({
+  flex: 1,
+  backgroundColor: "#F5F5F5",
+  borderRadius: "40px 0 0 40px",
+  padding: "10px 20px",
+  boxSizing: "border-box",
+  height: 40,
+  fontSize: 15,
+});
+
+export const planButton = style({
+  backgroundColor: "#94D376",
+  height: 40,
+  padding: "11px 0",
+  color: "#fff",
+  boxSizing: "border-box",
+  borderRadius: "0 40px 40px 0",
+  width: 60,
+  paddingRight: 5,
+});

--- a/src/app/study/(sections)/plan/plan-history.ts
+++ b/src/app/study/(sections)/plan/plan-history.ts
@@ -1,0 +1,142 @@
+export const planHistory = [
+  {
+    date: "2024.09.20",
+    list: [
+      {
+        id: 0,
+        checked: true,
+        content: "[자료구조] 큐와 스택 복습하기",
+      },
+      {
+        id: 1,
+        checked: false,
+        content: "[운영체제] 프로세스 스케줄링 알고리즘 학습하기",
+      },
+      {
+        id: 2,
+        checked: true,
+        content: "[컴퓨터 네트워크] OSI 7계층 학습하기",
+      },
+    ],
+  },
+  {
+    date: "2024.09.22",
+    list: [
+      {
+        id: 0,
+        checked: false,
+        content: "[자료구조] 이진 탐색 트리 복습하기",
+      },
+      {
+        id: 1,
+        checked: true,
+        content: "[운영체제] 메모리 관리 기법 학습하기",
+      },
+      {
+        id: 2,
+        checked: true,
+        content: "[컴퓨터 네트워크] TCP/UDP 차이점 정리하기",
+      },
+    ],
+  },
+  {
+    date: "2024.09.25",
+    list: [
+      {
+        id: 0,
+        checked: true,
+        content: "[자료구조] 해시 테이블 학습하기",
+      },
+      {
+        id: 1,
+        checked: true,
+        content: "[운영체제] 파일 시스템 구조 학습하기",
+      },
+      {
+        id: 2,
+        checked: false,
+        content: "[컴퓨터 네트워크] 라우팅 프로토콜 공부하기",
+      },
+    ],
+  },
+  {
+    date: "2024.09.30",
+    list: [
+      {
+        id: 0,
+        checked: true,
+        content: "[자료구조] 그래프 알고리즘 학습하기",
+      },
+      {
+        id: 1,
+        checked: true,
+        content: "[운영체제] 임계 구역 문제 복습하기",
+      },
+      {
+        id: 2,
+        checked: false,
+        content: "[컴퓨터 네트워크] IP 주소 및 서브넷팅 연습하기",
+      },
+    ],
+  },
+  {
+    date: "2024.10.03",
+    list: [
+      {
+        id: 0,
+        checked: true,
+        content: "[자료구조] 다익스트라 알고리즘 학습하기",
+      },
+      {
+        id: 1,
+        checked: false,
+        content: "[운영체제] 프로세스 동기화 방법 학습하기",
+      },
+      {
+        id: 2,
+        checked: true,
+        content: "[컴퓨터 네트워크] 스위칭과 라우팅 개념 정리하기",
+      },
+    ],
+  },
+  {
+    date: "2024.10.05",
+    list: [
+      {
+        id: 0,
+        checked: false,
+        content: "[자료구조] 분할 정복 알고리즘 학습하기",
+      },
+      {
+        id: 1,
+        checked: true,
+        content: "[운영체제] 프로세스 간 통신 복습하기",
+      },
+      {
+        id: 2,
+        checked: true,
+        content: "[컴퓨터 네트워크] 무선 네트워크의 개념 학습하기",
+      },
+    ],
+  },
+  {
+    date: "2024.10.08",
+    list: [
+      {
+        id: 0,
+        checked: true,
+        content: "[자료구조] 그래프 탐색 알고리즘 퀴즈 풀기",
+      },
+      {
+        id: 1,
+        checked: false,
+        content: "[운영체제] 스레드와 프로세스 비교하기",
+      },
+      {
+        id: 2,
+        checked: true,
+        content: "[컴퓨터 네트워크] IP 주소와 서브넷 마스크 연습하기",
+      },
+    ],
+  },
+];

--- a/src/app/study/(sections)/plan/plan.tsx
+++ b/src/app/study/(sections)/plan/plan.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { FaPlus } from "react-icons/fa6";
+
+import useModal from "@/hooks/useModal";
+
+import * as common from "../../styles.css";
+import * as styles from "./styles.css";
+
+export default function PlanSection() {
+  const { open } = useModal();
+  const handlePlanListButtonClick = () => {
+    open({ content: "test" });
+  };
+  return (
+    <section className={styles.planSection}>
+      <header className={common.styles.sectionHeader}>
+        <h3>오늘의 계획</h3>
+        <div className={styles.buttonContainer}>
+          <button onClick={handlePlanListButtonClick}>계획 목록</button>
+          <button>편집</button>
+        </div>
+      </header>
+      <ul className={styles.planList}>
+        <li>
+          <label>
+            <input type="checkbox" /> [컴퓨터 네트워크] 네트워크 유형 학습하기
+          </label>
+        </li>
+        <div className={styles.planInputSection}>
+          <input
+            type="text"
+            placeholder="오늘의 계획을 작성해주세요"
+            className={styles.planInput}
+          />
+          <button className={styles.planButton}>
+            <FaPlus />
+          </button>
+        </div>
+      </ul>
+    </section>
+  );
+}

--- a/src/app/study/(sections)/plan/plan.tsx
+++ b/src/app/study/(sections)/plan/plan.tsx
@@ -1,16 +1,22 @@
 "use client";
 
-import { FaPlus } from "react-icons/fa6";
-
 import useModal from "@/hooks/useModal";
 
+import PlanBox from "../../(components)/plan-box/plan-box";
+import { plans } from "../../(components)/plan-box/plans";
 import * as common from "../../styles.css";
+import { planHistory } from "./plan-history";
 import * as styles from "./styles.css";
 
 export default function PlanSection() {
   const { open } = useModal();
   const handlePlanListButtonClick = () => {
-    open({ content: "test" });
+    open({
+      title: "계획",
+      content: planHistory.map((item) => (
+        <PlanBox key={item.date} planData={item} />
+      )),
+    });
   };
   return (
     <section className={styles.planSection}>
@@ -21,23 +27,7 @@ export default function PlanSection() {
           <button>편집</button>
         </div>
       </header>
-      <ul className={styles.planList}>
-        <li>
-          <label>
-            <input type="checkbox" /> [컴퓨터 네트워크] 네트워크 유형 학습하기
-          </label>
-        </li>
-        <div className={styles.planInputSection}>
-          <input
-            type="text"
-            placeholder="오늘의 계획을 작성해주세요"
-            className={styles.planInput}
-          />
-          <button className={styles.planButton}>
-            <FaPlus />
-          </button>
-        </div>
-      </ul>
+      <PlanBox planData={plans} enterMode />
     </section>
   );
 }

--- a/src/app/study/(sections)/plan/styles.css.ts
+++ b/src/app/study/(sections)/plan/styles.css.ts
@@ -1,0 +1,44 @@
+import { style } from "@vanilla-extract/css";
+
+export const planSection = style({});
+
+export const buttonContainer = style({
+  display: "flex",
+  gap: 5,
+});
+
+export const planList = style({
+  marginTop: 15,
+  display: "flex",
+  padding: "25px",
+  border: "1px solid #93D092",
+  borderRadius: 12,
+  flexDirection: "column",
+});
+
+export const planInputSection = style({
+  display: "flex",
+  gap: 6,
+  marginTop: 20,
+});
+
+export const planInput = style({
+  flex: 1,
+  backgroundColor: "#F5F5F5",
+  borderRadius: "40px 0 0 40px",
+  padding: "10px 20px",
+  boxSizing: "border-box",
+  height: 40,
+  fontSize: 15,
+});
+
+export const planButton = style({
+  backgroundColor: "#94D376",
+  height: 40,
+  padding: "11px 0",
+  color: "#fff",
+  boxSizing: "border-box",
+  borderRadius: "0 40px 40px 0",
+  width: 40,
+  paddingRight: 5,
+});

--- a/src/app/study/(sections)/plan/styles.css.ts
+++ b/src/app/study/(sections)/plan/styles.css.ts
@@ -6,39 +6,3 @@ export const buttonContainer = style({
   display: "flex",
   gap: 5,
 });
-
-export const planList = style({
-  marginTop: 15,
-  display: "flex",
-  padding: "25px",
-  border: "1px solid #93D092",
-  borderRadius: 12,
-  flexDirection: "column",
-});
-
-export const planInputSection = style({
-  display: "flex",
-  gap: 6,
-  marginTop: 20,
-});
-
-export const planInput = style({
-  flex: 1,
-  backgroundColor: "#F5F5F5",
-  borderRadius: "40px 0 0 40px",
-  padding: "10px 20px",
-  boxSizing: "border-box",
-  height: 40,
-  fontSize: 15,
-});
-
-export const planButton = style({
-  backgroundColor: "#94D376",
-  height: 40,
-  padding: "11px 0",
-  color: "#fff",
-  boxSizing: "border-box",
-  borderRadius: "0 40px 40px 0",
-  width: 40,
-  paddingRight: 5,
-});

--- a/src/app/study/(sections)/study-list/study-list.tsx
+++ b/src/app/study/(sections)/study-list/study-list.tsx
@@ -1,3 +1,6 @@
+import StudyListItem from "@/components/study-list-item/study-list-item";
+import { studyList } from "@/mocks/study-list";
+
 import * as common from "../../styles.css";
 import * as styles from "./styles.css";
 
@@ -33,18 +36,10 @@ export default function StudyListSection() {
           </label>
         </div>
       </header>
-      <ul>
-        <li className={styles.studyListItem}>
-          <div className={styles.studyListThumbnail} />
-          <div className={styles.studyListItemInfo}>
-            <p>컴퓨터 네트워크</p>
-            <p>최근 수강일 24.09.03</p>
-            <div>
-              <span>50</span>
-              <span>27</span>
-            </div>
-          </div>
-        </li>
+      <ul className={styles.studyListContainer}>
+        {studyList.map((props) => (
+          <StudyListItem key={props.id} {...props} />
+        ))}
       </ul>
     </section>
   );

--- a/src/app/study/(sections)/study-list/study-list.tsx
+++ b/src/app/study/(sections)/study-list/study-list.tsx
@@ -1,0 +1,51 @@
+import * as common from "../../styles.css";
+import * as styles from "./styles.css";
+
+export default function StudyListSection() {
+  return (
+    <section className={styles.planSection} style={{ marginTop: 25 }}>
+      <header className={common.styles.sectionHeader}>
+        <h3>공부 목록</h3>
+        <div className={common.styles.buttonContainer}>
+          <button>편집</button>
+        </div>
+      </header>
+      <header
+        className={common.styles.sectionHeader}
+        style={{ margin: "10px 0" }}
+      >
+        <select>
+          <option>24-1학기</option>
+        </select>
+        <div className={common.styles.buttonContainer}>
+          <label className={styles.radioButton}>
+            <input
+              type="radio"
+              name="list-mode"
+              style={{ display: "none" }}
+              defaultChecked
+            />
+            공부 중
+          </label>
+          <label className={styles.radioButton}>
+            <input type="radio" name="list-mode" style={{ display: "none" }} />
+            스크랩
+          </label>
+        </div>
+      </header>
+      <ul>
+        <li className={styles.studyListItem}>
+          <div className={styles.studyListThumbnail} />
+          <div className={styles.studyListItemInfo}>
+            <p>컴퓨터 네트워크</p>
+            <p>최근 수강일 24.09.03</p>
+            <div>
+              <span>50</span>
+              <span>27</span>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+  );
+}

--- a/src/app/study/(sections)/study-list/styles.css.ts
+++ b/src/app/study/(sections)/study-list/styles.css.ts
@@ -13,24 +13,8 @@ export const radioButton = style({
   },
 });
 
-export const studyListItem = style({
-  border: "1px solid #93D092",
-  borderRadius: 12,
+export const studyListContainer = style({
   display: "flex",
-  padding: 12,
-  alignItems: "center",
-  gap: 16,
-});
-
-export const studyListThumbnail = style({
-  width: 100,
-  height: 100,
-  backgroundColor: "#F3F3F3",
-  borderRadius: 10,
-});
-
-export const studyListItemInfo = style({
-  display: "flex",
-  gap: 8,
   flexDirection: "column",
+  gap: 15,
 });

--- a/src/app/study/(sections)/study-list/styles.css.ts
+++ b/src/app/study/(sections)/study-list/styles.css.ts
@@ -1,0 +1,36 @@
+import { style } from "@vanilla-extract/css";
+
+export const planSection = style({});
+
+export const radioButton = style({
+  selectors: {
+    "&:hover": {
+      cursor: "pointer",
+    },
+    "&:has(input:checked)": {
+      color: "#3AB45C",
+    },
+  },
+});
+
+export const studyListItem = style({
+  border: "1px solid #93D092",
+  borderRadius: 12,
+  display: "flex",
+  padding: 12,
+  alignItems: "center",
+  gap: 16,
+});
+
+export const studyListThumbnail = style({
+  width: 100,
+  height: 100,
+  backgroundColor: "#F3F3F3",
+  borderRadius: 10,
+});
+
+export const studyListItemInfo = style({
+  display: "flex",
+  gap: 8,
+  flexDirection: "column",
+});

--- a/src/app/study/(sections)/tree/styles.css.ts
+++ b/src/app/study/(sections)/tree/styles.css.ts
@@ -1,0 +1,49 @@
+import { globalStyle, style } from "@vanilla-extract/css";
+
+import TreeImage from "@/assets/images/Tree.png";
+
+export const treeSection = style({
+  display: "flex",
+  width: 500,
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 15,
+});
+
+export const treeWrapper = style({
+  width: 400,
+  height: 400,
+  borderRadius: 20,
+  backgroundImage: `url(${TreeImage.src})`,
+});
+
+export const treeGrowthButton = style({
+  width: 400,
+  borderRadius: 20,
+  fontSize: 18,
+  fontWeight: 500,
+  color: "#333",
+  backgroundColor: "#FFF8BC",
+  padding: "10px 30px",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  lineHeight: "25px",
+  boxShadow: "2px 2px 4px rgba(0, 0, 0, 0.1)",
+  border: 0,
+});
+
+export const treeGrowthButtonIcon = style({
+  width: 25,
+  height: 25,
+  marginRight: 10,
+});
+export const treeGrowthButtonPoint = style({
+  color: "#FF6B00",
+});
+
+globalStyle(`${treeGrowthButton} span`, {
+  lineHeight: "25px",
+  display: "flex",
+  alignItems: "center",
+});

--- a/src/app/study/(sections)/tree/tree.tsx
+++ b/src/app/study/(sections)/tree/tree.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+
+import SparkleIcon from "@/assets/images/SparkleIcon.png";
+
+import * as styles from "./styles.css";
+
+export default function TreeSection() {
+  return (
+    <aside className={styles.treeSection}>
+      <div className={styles.treeWrapper} />
+      <button className={styles.treeGrowthButton}>
+        <span>
+          <Image
+            className={styles.treeGrowthButtonIcon}
+            src={SparkleIcon}
+            alt="tree-growth-button-icon"
+          />
+          <span>나무키우기</span>
+        </span>
+        <span className={styles.treeGrowthButtonPoint}>150P</span>
+      </button>
+    </aside>
+  );
+}

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { FaPlus } from "react-icons/fa6";
 
 import SparkleIcon from "../../assets/images/SparkleIcon.png";
 import { styles } from "./styles.css";
@@ -31,15 +32,75 @@ export default function Page() {
           <section className={styles.planSection}>
             <header className={styles.sectionHeader}>
               <h3>오늘의 계획</h3>
-              <div>
+              <div className={styles.buttonContainer}>
                 <button>계획 목록</button>
                 <button>편집</button>
               </div>
             </header>
-            <ul>
+            <ul className={styles.planList}>
               <li>
-                <input type="checkbox" /> [컴퓨터 네트워크] 네트워크 유형
-                학습하기
+                <label>
+                  <input type="checkbox" /> [컴퓨터 네트워크] 네트워크 유형
+                  학습하기
+                </label>
+              </li>
+              <div className={styles.planInputSection}>
+                <input
+                  type="text"
+                  placeholder="오늘의 계획을 작성해주세요"
+                  className={styles.planInput}
+                />
+                <button className={styles.planButton}>
+                  <FaPlus />
+                </button>
+              </div>
+            </ul>
+          </section>
+          <section className={styles.planSection} style={{ marginTop: 25 }}>
+            <header className={styles.sectionHeader}>
+              <h3>공부 목록</h3>
+              <div className={styles.buttonContainer}>
+                <button>편집</button>
+              </div>
+            </header>
+            <header
+              className={styles.sectionHeader}
+              style={{ margin: "10px 0" }}
+            >
+              <select>
+                <option>24-1학기</option>
+              </select>
+              <div className={styles.buttonContainer}>
+                <label className={styles.radioButton}>
+                  <input
+                    type="radio"
+                    name="list-mode"
+                    style={{ display: "none" }}
+                    defaultChecked
+                  />
+                  공부 중
+                </label>
+                <label className={styles.radioButton}>
+                  <input
+                    type="radio"
+                    name="list-mode"
+                    style={{ display: "none" }}
+                  />
+                  스크랩
+                </label>
+              </div>
+            </header>
+            <ul>
+              <li className={styles.studyListItem}>
+                <div className={styles.studyListThumbnail} />
+                <div className={styles.studyListItemInfo}>
+                  <p>컴퓨터 네트워크</p>
+                  <p>최근 수강일 24.09.03</p>
+                  <div>
+                    <span>50</span>
+                    <span>27</span>
+                  </div>
+                </div>
               </li>
             </ul>
           </section>

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -1,18 +1,10 @@
-"use client";
-
 import Image from "next/image";
-import { FaPlus } from "react-icons/fa6";
-
-import useModal from "@/hooks/useModal";
 
 import SparkleIcon from "../../assets/images/SparkleIcon.png";
+import PlanSection from "./(sections)/plan/plan";
 import { styles } from "./styles.css";
 
 export default function Page() {
-  const { open } = useModal();
-  const handlePlanListButtonClick = () => {
-    open({ content: "test" });
-  };
   return (
     <>
       <header className={styles.header}>
@@ -37,33 +29,7 @@ export default function Page() {
           </button>
         </aside>
         <div className={styles.listSection}>
-          <section className={styles.planSection}>
-            <header className={styles.sectionHeader}>
-              <h3>오늘의 계획</h3>
-              <div className={styles.buttonContainer}>
-                <button onClick={handlePlanListButtonClick}>계획 목록</button>
-                <button>편집</button>
-              </div>
-            </header>
-            <ul className={styles.planList}>
-              <li>
-                <label>
-                  <input type="checkbox" /> [컴퓨터 네트워크] 네트워크 유형
-                  학습하기
-                </label>
-              </li>
-              <div className={styles.planInputSection}>
-                <input
-                  type="text"
-                  placeholder="오늘의 계획을 작성해주세요"
-                  className={styles.planInput}
-                />
-                <button className={styles.planButton}>
-                  <FaPlus />
-                </button>
-              </div>
-            </ul>
-          </section>
+          <PlanSection />
           <section className={styles.planSection} style={{ marginTop: 25 }}>
             <header className={styles.sectionHeader}>
               <h3>공부 목록</h3>

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -1,10 +1,18 @@
+"use client";
+
 import Image from "next/image";
 import { FaPlus } from "react-icons/fa6";
+
+import useModal from "@/hooks/useModal";
 
 import SparkleIcon from "../../assets/images/SparkleIcon.png";
 import { styles } from "./styles.css";
 
 export default function Page() {
+  const { open } = useModal();
+  const handlePlanListButtonClick = () => {
+    open({ content: "test" });
+  };
   return (
     <>
       <header className={styles.header}>
@@ -33,7 +41,7 @@ export default function Page() {
             <header className={styles.sectionHeader}>
               <h3>오늘의 계획</h3>
               <div className={styles.buttonContainer}>
-                <button>계획 목록</button>
+                <button onClick={handlePlanListButtonClick}>계획 목록</button>
                 <button>편집</button>
               </div>
             </header>

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -1,9 +1,8 @@
-import Image from "next/image";
-
 import PageHeader from "@/components/page-header/page-header";
 
-import SparkleIcon from "../../assets/images/SparkleIcon.png";
 import PlanSection from "./(sections)/plan/plan";
+import StudyListSection from "./(sections)/study-list/study-list";
+import TreeSection from "./(sections)/tree/tree";
 import { styles } from "./styles.css";
 
 export default function Page() {
@@ -14,70 +13,10 @@ export default function Page() {
         desc="나무를 키우며 무한한 성장을 경험해보세요."
       />
       <div className={styles.main}>
-        <aside className={styles.treeSection}>
-          <div className={styles.treeWrapper} />
-          <button className={styles.treeGrowthButton}>
-            <span>
-              <Image
-                className={styles.treeGrowthButtonIcon}
-                src={SparkleIcon}
-                alt="tree-growth-button-icon"
-              />
-              <span>나무키우기</span>
-            </span>
-            <span className={styles.treeGrowthButtonPoint}>150P</span>
-          </button>
-        </aside>
+        <TreeSection />
         <div className={styles.listSection}>
           <PlanSection />
-          <section className={styles.planSection} style={{ marginTop: 25 }}>
-            <header className={styles.sectionHeader}>
-              <h3>공부 목록</h3>
-              <div className={styles.buttonContainer}>
-                <button>편집</button>
-              </div>
-            </header>
-            <header
-              className={styles.sectionHeader}
-              style={{ margin: "10px 0" }}
-            >
-              <select>
-                <option>24-1학기</option>
-              </select>
-              <div className={styles.buttonContainer}>
-                <label className={styles.radioButton}>
-                  <input
-                    type="radio"
-                    name="list-mode"
-                    style={{ display: "none" }}
-                    defaultChecked
-                  />
-                  공부 중
-                </label>
-                <label className={styles.radioButton}>
-                  <input
-                    type="radio"
-                    name="list-mode"
-                    style={{ display: "none" }}
-                  />
-                  스크랩
-                </label>
-              </div>
-            </header>
-            <ul>
-              <li className={styles.studyListItem}>
-                <div className={styles.studyListThumbnail} />
-                <div className={styles.studyListItemInfo}>
-                  <p>컴퓨터 네트워크</p>
-                  <p>최근 수강일 24.09.03</p>
-                  <div>
-                    <span>50</span>
-                    <span>27</span>
-                  </div>
-                </div>
-              </li>
-            </ul>
-          </section>
+          <StudyListSection />
         </div>
       </div>
     </>

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -1,5 +1,7 @@
 import Image from "next/image";
 
+import PageHeader from "@/components/page-header/page-header";
+
 import SparkleIcon from "../../assets/images/SparkleIcon.png";
 import PlanSection from "./(sections)/plan/plan";
 import { styles } from "./styles.css";
@@ -7,12 +9,10 @@ import { styles } from "./styles.css";
 export default function Page() {
   return (
     <>
-      <header className={styles.header}>
-        <div className={styles.headerContent}>
-          <h1>내 공부</h1>
-          <p>나무를 키우며 무한한 성장을 경험해보세요.</p>
-        </div>
-      </header>
+      <PageHeader
+        title="내 공부"
+        desc="나무를 키우며 무한한 성장을 경험해보세요."
+      />
       <div className={styles.main}>
         <aside className={styles.treeSection}>
           <div className={styles.treeWrapper} />

--- a/src/app/study/styles.css.ts
+++ b/src/app/study/styles.css.ts
@@ -1,7 +1,5 @@
 import { globalStyle, style } from "@vanilla-extract/css";
 
-import TreeImage from "../../assets/images/Tree.png";
-
 export const styles = {
   main: style({
     display: "flex",
@@ -12,51 +10,9 @@ export const styles = {
     gap: 120,
   }),
 
-  treeSection: style({
-    display: "flex",
-    width: 500,
-    flexDirection: "column",
-    alignItems: "center",
-    gap: 15,
-  }),
-
-  treeWrapper: style({
-    width: 400,
-    height: 400,
-    borderRadius: 20,
-    backgroundImage: `url(${TreeImage.src})`,
-  }),
-
-  treeGrowthButton: style({
-    width: 400,
-    borderRadius: 20,
-    fontSize: 18,
-    fontWeight: 500,
-    color: "#333",
-    backgroundColor: "#FFF8BC",
-    padding: "10px 30px",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    lineHeight: "25px",
-    boxShadow: "2px 2px 4px rgba(0, 0, 0, 0.1)",
-    border: 0,
-  }),
-
-  treeGrowthButtonIcon: style({
-    width: 25,
-    height: 25,
-    marginRight: 10,
-  }),
-  treeGrowthButtonPoint: style({
-    color: "#FF6B00",
-  }),
-
   listSection: style({
     width: "100%",
   }),
-
-  planSection: style({}),
 
   sectionHeader: style({
     display: "flex",
@@ -67,82 +23,7 @@ export const styles = {
     display: "flex",
     gap: 5,
   }),
-
-  planList: style({
-    marginTop: 15,
-    display: "flex",
-    padding: "25px",
-    border: "1px solid #93D092",
-    borderRadius: 12,
-    flexDirection: "column",
-  }),
-
-  planInputSection: style({
-    display: "flex",
-    gap: 6,
-    marginTop: 20,
-  }),
-
-  planInput: style({
-    flex: 1,
-    backgroundColor: "#F5F5F5",
-    borderRadius: "40px 0 0 40px",
-    padding: "10px 20px",
-    boxSizing: "border-box",
-    height: 40,
-    fontSize: 15,
-  }),
-
-  planButton: style({
-    backgroundColor: "#94D376",
-    height: 40,
-    padding: "11px 0",
-    color: "#fff",
-    boxSizing: "border-box",
-    borderRadius: "0 40px 40px 0",
-    width: 40,
-    paddingRight: 5,
-  }),
-
-  radioButton: style({
-    selectors: {
-      "&:hover": {
-        cursor: "pointer",
-      },
-      "&:has(input:checked)": {
-        color: "#3AB45C",
-      },
-    },
-  }),
-
-  studyListItem: style({
-    border: "1px solid #93D092",
-    borderRadius: 12,
-    display: "flex",
-    padding: 12,
-    alignItems: "center",
-    gap: 16,
-  }),
-
-  studyListThumbnail: style({
-    width: 100,
-    height: 100,
-    backgroundColor: "#F3F3F3",
-    borderRadius: 10,
-  }),
-
-  studyListItemInfo: style({
-    display: "flex",
-    gap: 8,
-    flexDirection: "column",
-  }),
 };
-
-globalStyle(`${styles.treeGrowthButton} span`, {
-  lineHeight: "25px",
-  display: "flex",
-  alignItems: "center",
-});
 
 globalStyle(`${styles.sectionHeader} button`, {
   backgroundColor: "#E3EDE2",

--- a/src/app/study/styles.css.ts
+++ b/src/app/study/styles.css.ts
@@ -3,17 +3,6 @@ import { globalStyle, style } from "@vanilla-extract/css";
 import TreeImage from "../../assets/images/Tree.png";
 
 export const styles = {
-  header: style({
-    padding: 40,
-    backgroundColor: "#F6FBF4",
-  }),
-
-  headerContent: style({
-    minWidth: 1100,
-    width: "60vw",
-    margin: "0 auto",
-  }),
-
   main: style({
     display: "flex",
     minWidth: 1100,
@@ -148,12 +137,6 @@ export const styles = {
     flexDirection: "column",
   }),
 };
-
-globalStyle(`${styles.header} p`, {
-  marginTop: 10,
-  fontSize: 18,
-  color: "#5C5C5C",
-});
 
 globalStyle(`${styles.treeGrowthButton} span`, {
   lineHeight: "25px",

--- a/src/app/study/styles.css.ts
+++ b/src/app/study/styles.css.ts
@@ -20,7 +20,7 @@ export const styles = {
     margin: "40px auto",
     width: "60vw",
     flex: "1 auto",
-    gap: 20,
+    gap: 120,
   }),
 
   treeSection: style({
@@ -51,6 +51,7 @@ export const styles = {
     justifyContent: "space-between",
     lineHeight: "25px",
     boxShadow: "2px 2px 4px rgba(0, 0, 0, 0.1)",
+    border: 0,
   }),
 
   treeGrowthButtonIcon: style({
@@ -62,11 +63,90 @@ export const styles = {
     color: "#FF6B00",
   }),
 
-  listSection: style({}),
+  listSection: style({
+    width: "100%",
+  }),
 
   planSection: style({}),
 
-  sectionHeader: style({}),
+  sectionHeader: style({
+    display: "flex",
+    justifyContent: "space-between",
+  }),
+
+  buttonContainer: style({
+    display: "flex",
+    gap: 5,
+  }),
+
+  planList: style({
+    marginTop: 15,
+    display: "flex",
+    padding: "25px",
+    border: "1px solid #93D092",
+    borderRadius: 12,
+    flexDirection: "column",
+  }),
+
+  planInputSection: style({
+    display: "flex",
+    gap: 6,
+    marginTop: 20,
+  }),
+
+  planInput: style({
+    flex: 1,
+    backgroundColor: "#F5F5F5",
+    borderRadius: "40px 0 0 40px",
+    padding: "10px 20px",
+    boxSizing: "border-box",
+    height: 40,
+    fontSize: 15,
+  }),
+
+  planButton: style({
+    backgroundColor: "#94D376",
+    height: 40,
+    padding: "11px 0",
+    color: "#fff",
+    boxSizing: "border-box",
+    borderRadius: "0 40px 40px 0",
+    width: 40,
+    paddingRight: 5,
+  }),
+
+  radioButton: style({
+    selectors: {
+      "&:hover": {
+        cursor: "pointer",
+      },
+      "&:has(input:checked)": {
+        color: "#3AB45C",
+      },
+    },
+  }),
+
+  studyListItem: style({
+    border: "1px solid #93D092",
+    borderRadius: 12,
+    display: "flex",
+    padding: 12,
+    alignItems: "center",
+    gap: 16,
+  }),
+
+  studyListThumbnail: style({
+    width: 100,
+    height: 100,
+    backgroundColor: "#F3F3F3",
+    borderRadius: 10,
+  }),
+
+  studyListItemInfo: style({
+    display: "flex",
+    gap: 8,
+    flexDirection: "column",
+  }),
 };
 
 globalStyle(`${styles.header} p`, {
@@ -79,4 +159,12 @@ globalStyle(`${styles.treeGrowthButton} span`, {
   lineHeight: "25px",
   display: "flex",
   alignItems: "center",
+});
+
+globalStyle(`${styles.sectionHeader} button`, {
+  backgroundColor: "#E3EDE2",
+  padding: "0 9px",
+  borderRadius: 5,
+  color: "#3B4C45",
+  fontSize: 12,
 });

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,0 +1,22 @@
+import React, { HTMLAttributes } from "react";
+
+import { button } from "./styles.css";
+
+type ButtonProps = HTMLAttributes<HTMLButtonElement>;
+
+export default function Button({
+  value,
+  theme,
+  size,
+  ...props
+}: {
+  value: string;
+  theme?: "primary";
+  size?: "full" | "fit";
+} & ButtonProps) {
+  return (
+    <button className={button({ theme, size })} type="button" {...props}>
+      {value}
+    </button>
+  );
+}

--- a/src/components/button/styles.css.ts
+++ b/src/components/button/styles.css.ts
@@ -1,0 +1,22 @@
+import { recipe } from "@vanilla-extract/recipes";
+
+export const button = recipe({
+  base: {
+    padding: "16px 0",
+    color: "#fff",
+    borderRadius: 10,
+  },
+  variants: {
+    theme: {
+      primary: { backgroundColor: "#86DA7F" },
+    },
+    size: {
+      full: { width: "100%" },
+      fit: { width: "fit" },
+    },
+  },
+  defaultVariants: {
+    theme: "primary",
+    size: "full",
+  },
+});

--- a/src/components/modal/modal-provider.tsx
+++ b/src/components/modal/modal-provider.tsx
@@ -6,12 +6,12 @@ import { createPortal } from "react-dom";
 import { useModalStateStore } from "@/hooks/stores/useModalStateStore";
 
 import Modal from "./modal";
-import { styles } from "./styles.css";
+import * as styles from "./styles.css";
 
 export default function ModalProvider({ children }: { children: ReactNode }) {
   const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
   const {
-    modalState: { visible, content },
+    modalState: { visible, content, title },
   } = useModalStateStore();
 
   useEffect(() => {
@@ -22,7 +22,7 @@ export default function ModalProvider({ children }: { children: ReactNode }) {
     ? createPortal(
         <>
           <div className={styles.wrapper}>
-            <Modal content={content} />
+            <Modal title={title} content={content} />
           </div>
           {children}
         </>,

--- a/src/components/modal/modal-provider.tsx
+++ b/src/components/modal/modal-provider.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { useModalStateStore } from "@/hooks/stores/useModalStateStore";
+
+import Modal from "./modal";
+import { styles } from "./styles.css";
+
+export default function ModalProvider({ children }: { children: ReactNode }) {
+  const [portalElement, setPortalElement] = useState<HTMLElement | null>(null);
+  const {
+    modalState: { visible, content },
+  } = useModalStateStore();
+
+  useEffect(() => {
+    setPortalElement(document.querySelector("#modal-root") as HTMLElement);
+  }, []);
+
+  return portalElement && visible
+    ? createPortal(
+        <>
+          <div className={styles.wrapper}>
+            <Modal content={content} />
+          </div>
+          {children}
+        </>,
+        portalElement!,
+      )
+    : children;
+}

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+
+import useModal from "@/hooks/useModal";
+
+import Button from "../button/button";
+import { styles } from "./styles.css";
+
+export default function Modal({ content }: { content: ReactNode }) {
+  const { close } = useModal();
+  return (
+    <div className={styles.container}>
+      <div>
+        {content}
+        <Button value="닫기" onClick={close} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,18 +1,29 @@
 import { ReactNode } from "react";
+import { RxCross2 } from "react-icons/rx";
 
 import useModal from "@/hooks/useModal";
 
 import Button from "../button/button";
-import { styles } from "./styles.css";
+import * as styles from "./styles.css";
 
-export default function Modal({ content }: { content: ReactNode }) {
+export default function Modal({
+  title,
+  content,
+}: {
+  title?: string;
+  content: ReactNode;
+}) {
   const { close } = useModal();
   return (
     <div className={styles.container}>
-      <div>
-        {content}
-        <Button value="닫기" onClick={close} />
+      <div className={styles.header}>
+        <p className={styles.title}>{title}</p>
+        <button className={styles.crossButton} onClick={close}>
+          <RxCross2 />
+        </button>
       </div>
+      <div className={styles.content}>{content}</div>
+      <Button value="닫기" onClick={close} />
     </div>
   );
 }

--- a/src/components/modal/styles.css.ts
+++ b/src/components/modal/styles.css.ts
@@ -1,25 +1,48 @@
 import { style } from "@vanilla-extract/css";
 
-export const styles = {
-  wrapper: style({
-    width: "100%",
-    height: "100dvh",
-    position: "absolute",
-    backgroundColor: "rgba(0,0,0,0.2)",
-    top: 0,
-    left: 0,
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    zIndex: 999,
-  }),
-  container: style({
-    maxWidth: 390,
-    width: "90vw",
-    maxHeight: 500,
-    backgroundColor: "white",
-    borderRadius: 10,
-    overflow: "hidden",
-    padding: 10,
-  }),
-};
+export const wrapper = style({
+  width: "100%",
+  height: "100dvh",
+  position: "absolute",
+  backgroundColor: "rgba(0,0,0,0.2)",
+  top: 0,
+  left: 0,
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  zIndex: 999,
+});
+
+export const container = style({
+  maxWidth: 700,
+  width: "90vw",
+  maxHeight: 500,
+  backgroundColor: "white",
+  borderRadius: 10,
+  overflow: "hidden",
+  padding: "10px 30px",
+  display: "flex",
+  flexDirection: "column",
+  gap: 10,
+});
+
+export const content = style({
+  overflow: "auto",
+  flex: 1,
+});
+
+export const crossButton = style({
+  display: "flex",
+  justifyContent: "end",
+  fontSize: 30,
+});
+
+export const header = style({
+  display: "flex",
+  justifyContent: "space-between",
+});
+
+export const title = style({
+  fontWeight: "bold",
+  fontSize: 20,
+});

--- a/src/components/modal/styles.css.ts
+++ b/src/components/modal/styles.css.ts
@@ -1,0 +1,25 @@
+import { style } from "@vanilla-extract/css";
+
+export const styles = {
+  wrapper: style({
+    width: "100%",
+    height: "100dvh",
+    position: "absolute",
+    backgroundColor: "rgba(0,0,0,0.2)",
+    top: 0,
+    left: 0,
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 999,
+  }),
+  container: style({
+    maxWidth: 390,
+    width: "90vw",
+    maxHeight: 500,
+    backgroundColor: "white",
+    borderRadius: 10,
+    overflow: "hidden",
+    padding: 10,
+  }),
+};

--- a/src/components/page-header/page-header.tsx
+++ b/src/components/page-header/page-header.tsx
@@ -1,0 +1,18 @@
+import * as styles from "./styles.css";
+
+export default function PageHeader({
+  title,
+  desc,
+}: {
+  title: string;
+  desc: string;
+}) {
+  return (
+    <header className={styles.header}>
+      <div className={styles.headerContent}>
+        <h1>{title}</h1>
+        <p>{desc}</p>
+      </div>
+    </header>
+  );
+}

--- a/src/components/page-header/styles.css.ts
+++ b/src/components/page-header/styles.css.ts
@@ -1,0 +1,18 @@
+import { globalStyle, style } from "@vanilla-extract/css";
+
+export const header = style({
+  padding: 40,
+  backgroundColor: "#F6FBF4",
+});
+
+export const headerContent = style({
+  minWidth: 1100,
+  width: "60vw",
+  margin: "0 auto",
+});
+
+globalStyle(`${header} p`, {
+  marginTop: 10,
+  fontSize: 18,
+  color: "#5C5C5C",
+});

--- a/src/components/study-list-item/study-list-item.tsx
+++ b/src/components/study-list-item/study-list-item.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { GoThumbsup } from "react-icons/go";
+import { TfiBook } from "react-icons/tfi";
+
+import { studyListItem } from "@/types/study";
+
+import * as styles from "./styles.css";
+
+export default function StudyListItem({
+  id,
+  title,
+  date,
+  scrap,
+  like,
+}: studyListItem) {
+  return (
+    <Link href={`/study/${id}`} className={styles.studyListItem}>
+      <div className={styles.studyListThumbnail} />
+      <div className={styles.studyListItemInfo}>
+        <p className={styles.title}>{title}</p>
+        <p className={styles.date}>최근 수강일 {date}</p>
+        <div className={styles.info}>
+          <span>
+            <GoThumbsup />
+            {like}
+          </span>
+          <span>|</span>
+          <span>
+            <TfiBook />
+            {scrap}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/study-list-item/styles.css.ts
+++ b/src/components/study-list-item/styles.css.ts
@@ -1,0 +1,48 @@
+import { globalStyle, style } from "@vanilla-extract/css";
+
+export const studyListItem = style({
+  border: "1px solid #93D092",
+  borderRadius: 12,
+  display: "flex",
+  padding: 12,
+  alignItems: "center",
+  gap: 16,
+});
+
+export const studyListThumbnail = style({
+  width: 100,
+  height: 100,
+  backgroundColor: "#F3F3F3",
+  borderRadius: 10,
+});
+
+export const studyListItemInfo = style({
+  display: "flex",
+  gap: 5,
+  flexDirection: "column",
+});
+
+export const title = style({
+  fontWeight: "bold",
+});
+export const date = style({
+  color: "#838383",
+  fontSize: 15,
+});
+export const info = style({
+  backgroundColor: "#F3F3F3",
+  width: 120,
+  justifyContent: "space-around",
+  padding: "2px 5px",
+  borderRadius: 20,
+  display: "flex",
+  color: "#5F5F5F",
+  fontSize: 14,
+  alignItems: "center",
+});
+
+globalStyle(`${info} span`, {
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+});

--- a/src/hooks/stores/useModalStateStore.ts
+++ b/src/hooks/stores/useModalStateStore.ts
@@ -1,0 +1,20 @@
+import { ReactNode } from "react";
+import { create } from "zustand";
+
+type ModalState = {
+  modalState: Modal;
+  setModalState: (state: Modal) => void;
+};
+
+type Modal = {
+  visible: boolean;
+  content: ReactNode;
+};
+
+export const useModalStateStore = create<ModalState>((set) => ({
+  modalState: {
+    visible: false,
+    content: null,
+  },
+  setModalState: (state: Modal) => set({ modalState: state }),
+}));

--- a/src/hooks/stores/useModalStateStore.ts
+++ b/src/hooks/stores/useModalStateStore.ts
@@ -8,12 +8,14 @@ type ModalState = {
 
 type Modal = {
   visible: boolean;
+  title?: string;
   content: ReactNode;
 };
 
 export const useModalStateStore = create<ModalState>((set) => ({
   modalState: {
     visible: false,
+    title: undefined,
     content: null,
   },
   setModalState: (state: Modal) => set({ modalState: state }),

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -5,12 +5,12 @@ import { useModalStateStore } from "./stores/useModalStateStore";
 export default function useModal() {
   const { setModalState } = useModalStateStore();
 
-  const open = ({ content }: { content: ReactNode }) => {
-    setModalState({ visible: true, content });
+  const open = ({ title, content }: { title?: string; content: ReactNode }) => {
+    setModalState({ visible: true, content, title });
   };
 
   const close = () => {
-    setModalState({ visible: false, content: null });
+    setModalState({ visible: false, content: null, title: undefined });
   };
 
   return { open, close };

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+
+import { useModalStateStore } from "./stores/useModalStateStore";
+
+export default function useModal() {
+  const { setModalState } = useModalStateStore();
+
+  const open = ({ content }: { content: ReactNode }) => {
+    setModalState({ visible: true, content });
+  };
+
+  const close = () => {
+    setModalState({ visible: false, content: null });
+  };
+
+  return { open, close };
+}

--- a/src/mocks/study-list.ts
+++ b/src/mocks/study-list.ts
@@ -1,0 +1,19 @@
+export const studyList = [
+  { id: 0, title: "컴퓨터 네트워크", date: "24.09.03", like: 50, scrap: 27 },
+  { id: 1, title: "자료구조", date: "24.09.05", like: 45, scrap: 19 },
+  { id: 2, title: "운영체제", date: "24.09.07", like: 60, scrap: 34 },
+  { id: 3, title: "알고리즘", date: "24.09.10", like: 40, scrap: 22 },
+  { id: 4, title: "데이터베이스", date: "24.09.12", like: 55, scrap: 25 },
+  {
+    id: 5,
+    title: "객체지향 프로그래밍",
+    date: "24.09.15",
+    like: 70,
+    scrap: 30,
+  },
+  { id: 6, title: "웹 개발", date: "24.09.17", like: 85, scrap: 45 },
+  { id: 7, title: "운영체제", date: "24.09.20", like: 50, scrap: 20 },
+  { id: 8, title: "소프트웨어 공학", date: "24.09.22", like: 65, scrap: 38 },
+  { id: 9, title: "네트워크 보안", date: "24.09.25", like: 75, scrap: 40 },
+  { id: 10, title: "디지털 논리회로", date: "24.09.27", like: 60, scrap: 28 },
+];

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -38,6 +38,7 @@ a {
 button {
   border: none;
   cursor: pointer;
+  background-color: transparent;
 }
 input {
   border: 0;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -39,6 +39,16 @@ button {
   border: none;
   cursor: pointer;
 }
+input {
+  border: 0;
+  &:focus {
+    outline: none;
+  }
+}
+
+li {
+  list-style: none;
+}
 
 @media (prefers-color-scheme: dark) {
   html {

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -1,0 +1,10 @@
+export interface PlanData {
+  date: string;
+  list: Plan[];
+}
+
+export interface Plan {
+  id: number;
+  content: string;
+  checked: boolean;
+}

--- a/src/types/study.ts
+++ b/src/types/study.ts
@@ -1,0 +1,7 @@
+export interface studyListItem {
+  id: number;
+  title: string;
+  date: string;
+  like: number;
+  scrap: number;
+}


### PR DESCRIPTION
## 📝 What is this PR?

학습 페이지의 계획 목록 모달을 작성하고, 스타일을 적용하였으며, 반복 사용되는 컴포넌트를 공용 컴포넌트로 분리하여 코드 가독성을 높였습니다.


## ✅ Changes
- react-icons 라이브러리를 설치하였습니다.
- 상태 관리 라이브러리인 zustand를 설치하였습니다.
- 모달 훅을 작성하였습니다.
- 계획 박스와 스터디 리스트 아이템을 공용 컴포넌트로 분리하였습니다.
- 페이지 헤더인 PageHeader 공용 컴포넌트를 작성하였습니다.

## ⚠️ To Reviewers
- 스크롤이 활성화된 화면에서 모달을 표시하였을 때 스크롤을 비활성화하는 것을 놓쳐 다음 PR에 적용하도록 하겠습니다.

## 🎉 Result
![image](https://github.com/user-attachments/assets/9d255190-042f-4c78-8121-631476dde348)
![image](https://github.com/user-attachments/assets/cf72e3b6-61a9-43bb-81eb-d59a02736018)
